### PR TITLE
Bug fix: Check updates returns a nil release when there is no one.

### DIFF
--- a/updater/find_update.go
+++ b/updater/find_update.go
@@ -43,6 +43,10 @@ func findUpdateUseCache(client pvdr.HTTPClientPlugin, provider pvdr.UpdaterProvi
 			return nil, err
 		}
 
+		if release == nil {
+			release = &pvdr.Release{}
+		}
+
 		_ = provider.CacheRelease(*release)
 	}
 


### PR DESCRIPTION
Check updates returns a nil release when there is no one. Closes #21.